### PR TITLE
fix: sync browser session expiry state

### DIFF
--- a/bridge-browser/index.html
+++ b/bridge-browser/index.html
@@ -32,6 +32,10 @@
         background: #ffb74d;
         box-shadow: 0 0 8px rgba(255, 183, 77, 0.35);
       }
+      .status-dot.expired {
+        background: #ef5350;
+        box-shadow: 0 0 8px rgba(239, 83, 80, 0.35);
+      }
 
       .card {
         background: #252526;
@@ -62,6 +66,14 @@
         border-color: #5a482a;
         background: #2e2a20;
       }
+      .status-card.expired {
+        border-color: #61413a;
+        background: #2b2421;
+      }
+      .status-card.checking {
+        border-color: #3a4654;
+        background: #232a32;
+      }
       .connection-label {
         color: #fff;
         font-weight: 600;
@@ -72,6 +84,12 @@
       }
       .connection-label.suspended {
         color: #ffd89b;
+      }
+      .connection-label.expired {
+        color: #ffc0ad;
+      }
+      .connection-label.checking {
+        color: #cfe7ff;
       }
       .status-meta {
         flex: none;
@@ -95,6 +113,17 @@
       .suspended-hint {
         color: #d9c7a4;
         font-size: 12px;
+      }
+      .expired-card {
+        background: #332c24;
+        border: 1px solid #6b5635;
+        border-radius: 6px;
+        box-sizing: border-box;
+        padding: 12px;
+      }
+      .expired-desc {
+        color: #f0d6a8;
+        font-size: 11px;
       }
       .install-card {
         display: flex;
@@ -302,7 +331,17 @@
       </div>
     </div>
 
-    <div id="disconnectedView">
+    <div id="loadingView">
+      <div class="disconnected-stack">
+        <div class="card status-card checking">
+          <p id="checkingTitle" class="connection-label checking">
+            Checking VS Code connection...
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div id="disconnectedView" class="hidden">
       <div class="disconnected-stack">
         <div id="disconnectedStatusCard" class="card status-card disconnected">
           <p id="disconnectedTitle" class="connection-label disconnected">
@@ -313,6 +352,16 @@
         <p id="suspendedHint" class="card suspended-hint hidden">
           The VS Code connection is paused on this page. Return to the connected site to resume automatically.
         </p>
+
+        <div id="expiredCard" class="expired-card hidden">
+          <p class="section-title">
+            <span id="expiredActionTitle">Reconnect from VS Code</span>
+          </p>
+          <p id="expiredActionDesc" class="expired-desc">
+            The VS Code gateway may have stopped after inactivity. In VS Code, click webcode in the status bar,
+            start the service, then launch the site again.
+          </p>
+        </div>
 
         <div id="installCard" class="install-card">
           <div class="install-section installed-action-card">

--- a/bridge-browser/manifest.json
+++ b/bridge-browser/manifest.json
@@ -10,7 +10,7 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "permissions": ["storage", "notifications", "offscreen"],
+  "permissions": ["storage", "notifications", "offscreen", "alarms"],
   "host_permissions": [
     "http://127.0.0.1/*",
     "http://localhost/*",

--- a/bridge-browser/src/background/badge.ts
+++ b/bridge-browser/src/background/badge.ts
@@ -1,8 +1,12 @@
 export function updateBadge(tabId: number, active: boolean) {
   if (active) {
-    void chrome.action.setBadgeText({ tabId, text: "ON" });
-    void chrome.action.setBadgeBackgroundColor({ tabId, color: "#4CAF50" });
+    void chrome.action.setBadgeText({ tabId, text: "ON" }).catch(ignoreRuntimeError);
+    void chrome.action.setBadgeBackgroundColor({ tabId, color: "#4CAF50" }).catch(ignoreRuntimeError);
   } else {
-    void chrome.action.setBadgeText({ tabId, text: "" });
+    void chrome.action.setBadgeText({ tabId, text: "" }).catch(ignoreRuntimeError);
   }
+}
+
+function ignoreRuntimeError(_error: unknown): void {
+  void chrome.runtime.lastError;
 }

--- a/bridge-browser/src/background/connection.ts
+++ b/bridge-browser/src/background/connection.ts
@@ -4,6 +4,7 @@ import { type HandshakeResponse, isStoredSession, type MessageRequest } from '..
 import { updateBadge } from './badge';
 import { fetchInitDataFromGateway } from './init_sync';
 import { getSessionPresetSettings } from './presets';
+import { clearSessionExpiryCheck, scheduleSessionExpiryCheck } from './session_health';
 import { removeSession, saveSession } from './sessions';
 
 interface HandshakeParams {
@@ -35,7 +36,9 @@ export async function handleHandshake(request: MessageRequest, tabId: number | n
           return { success: false, error: "BUSY", conflictTabId };
         }
       } catch {
-        await removeSession(parseInt(conflictTabId, 10));
+        const staleTabId = parseInt(conflictTabId, 10);
+        await removeSession(staleTabId);
+        await clearSessionExpiryCheck(staleTabId);
       }
     }
   }
@@ -61,6 +64,7 @@ interface BindSessionOptions {
 
 export async function bindSession(tabId: number, options: BindSessionOptions) {
   const presetSettings = await getSessionPresetSettings();
+  const lastGatewayActivityAt = Date.now();
   const session = {
     port: options.port,
     token: options.token,
@@ -68,11 +72,13 @@ export async function bindSession(tabId: number, options: BindSessionOptions) {
     autoSend: true,
     autoApproveTools: presetSettings.defaultAutoApproveTools,
     workspaceId: options.workspaceId,
+    lastGatewayActivityAt,
     siteId: options.siteId,
     targetOrigin: options.targetOrigin,
     targetUrl: options.targetUrl,
   };
   await saveSession(tabId, session);
+  scheduleSessionExpiryCheck(tabId, lastGatewayActivityAt);
   console.log(`${BRANDING.logPrefix} Tab ${tabId} bound to Port ${options.port} [Workspace: ${options.workspaceId}]`);
   updateBadge(tabId, true);
   // [Sync] Notify Content Script

--- a/bridge-browser/src/background/defaults.ts
+++ b/bridge-browser/src/background/defaults.ts
@@ -8,7 +8,9 @@ export async function handleInstalled(details?: chrome.runtime.InstalledDetails)
 
 async function clearStoredSessions(): Promise<void> {
   const localItems = await chrome.storage.local.get(null) as Record<string, unknown>;
-  const sessionKeys = Object.keys(localItems).filter((key) => key.startsWith('session_'));
+  const sessionKeys = Object.keys(localItems).filter(
+    (key) => key.startsWith('session_') || key.startsWith('disconnect_')
+  );
 
   if (sessionKeys.length === 0) {
     return;

--- a/bridge-browser/src/background/gateway.ts
+++ b/bridge-browser/src/background/gateway.ts
@@ -2,6 +2,7 @@ import { PROTOCOL } from '@webcode/shared';
 
 import { isRecord, type MessageRequest, type ToolExecutionPayload } from '../types';
 import { getErrorMessage } from './errors';
+import { expireGatewaySession, recordGatewayActivity } from './session_health';
 import { getActiveProtocolSessionResult, type ActiveProtocolSessionResult } from './sessions';
 
 type InactiveProtocolSessionStatus = Exclude<ActiveProtocolSessionResult["status"], "active">;
@@ -36,10 +37,12 @@ export async function executeTool(
         arguments: payload.arguments ?? {},
       }),
     });
+    await recordGatewayActivity(tabId);
     if (response.ok) {
       return parseSuccessfulGatewayResponse(await response.json());
     }
     if (response.status === 403) {
+      await expireGatewaySession(tabId, "invalid_token");
       return { success: false, error: "Session Expired/Invalid Token." };
     }
     const errorText = await readGatewayError(response);
@@ -48,6 +51,7 @@ export async function executeTool(
       error: errorText || `${response.status} - ${response.statusText}`,
     };
   } catch (err: unknown) {
+    await expireGatewaySession(tabId, "gateway_unavailable");
     return { success: false, error: `Connection Failed: ${getErrorMessage(err)}` };
   }
 }

--- a/bridge-browser/src/background/index.ts
+++ b/bridge-browser/src/background/index.ts
@@ -1,12 +1,17 @@
 import { handleInstalled } from './defaults';
 import { handleRuntimeMessage } from './messages';
 import { handleNotificationClicked } from './notifications';
+import { handleSessionExpiryAlarm, scheduleStoredSessionExpiryChecks } from './session_health';
 import { handleTabRemoved, handleTabUpdated } from './tab_lifecycle';
 
 // === Background Service (MV3 Persistent Edition) ===
 
 // 初始化：设置默认状态
 chrome.runtime.onInstalled.addListener(handleInstalled);
+chrome.runtime.onStartup.addListener(() => {
+  void scheduleStoredSessionExpiryChecks();
+});
+void scheduleStoredSessionExpiryChecks();
 
 // === 保持连接逻辑 & 安全熔断 ===
 chrome.tabs.onUpdated.addListener(handleTabUpdated);
@@ -17,3 +22,5 @@ chrome.runtime.onMessage.addListener(handleRuntimeMessage);
 chrome.notifications.onClicked.addListener(handleNotificationClicked);
 
 chrome.tabs.onRemoved.addListener(handleTabRemoved);
+
+chrome.alarms.onAlarm.addListener(handleSessionExpiryAlarm);

--- a/bridge-browser/src/background/messages.ts
+++ b/bridge-browser/src/background/messages.ts
@@ -1,12 +1,14 @@
-import { isMessageRequest, type MessageRequest } from '../types';
+import { isMessageRequest, type MessageRequest, type SessionDisconnectReason } from '../types';
 import { playAttentionSound } from './attention_sound';
 import { handleHandshake } from './connection';
 import { getErrorMessage } from './errors';
 import { executeTool } from './gateway';
 import { showNotification, updateWindowAttention } from './notifications';
-import { getSessionPresetSettings, updateDefaultAutoApproveTools } from './presets';
+import { getSessionPresetSettings, updateDefaultAutoApproveTools, type SessionPresetSettings } from './presets';
+import { checkGatewayHealth, expireGatewaySession, type GatewayHealthStatus } from './session_health';
 import {
   getActiveProtocolSessionResult,
+  getSessionDisconnectReason,
   updateSessionAutoApproveTools,
   updateSessionAutoSend,
   updateSessionLog,
@@ -107,31 +109,26 @@ async function getStatusResponse(targetTabId: number) {
     getSessionPresetSettings(),
   ]);
   if (sessionResult.status === "missing") {
-    return {
-      connected: false,
-      suspended: false,
-      showLog: false,
-      autoSend: true,
-      autoApproveTools: false,
-      defaultAutoApproveTools: presetSettings.defaultAutoApproveTools,
-      workspaceId: 'global',
-    };
+    const disconnectReason = await getSessionDisconnectReason(targetTabId);
+    return createDisconnectedStatusResponse(presetSettings, disconnectReason);
   }
 
   if (sessionResult.status === "invalid") {
-    return {
-      connected: false,
-      suspended: false,
-      showLog: false,
-      autoSend: true,
-      autoApproveTools: false,
-      defaultAutoApproveTools: presetSettings.defaultAutoApproveTools,
-      workspaceId: 'global',
-      error: "Session data is incomplete. Reconnect from VS Code to continue.",
-    };
+    return createDisconnectedStatusResponse(
+      presetSettings,
+      "invalid_session",
+      "Session data is incomplete. Reconnect from VS Code to continue."
+    );
   }
 
   const session = sessionResult.session;
+  const healthStatus = await checkGatewayHealth(session);
+  if (healthStatus !== "online") {
+    const disconnectReason = getDisconnectReasonForHealthStatus(healthStatus);
+    await expireGatewaySession(targetTabId, disconnectReason);
+    return createDisconnectedStatusResponse(presetSettings, disconnectReason);
+  }
+
   const isActive = sessionResult.status === "active";
   return {
     connected: isActive,
@@ -144,6 +141,28 @@ async function getStatusResponse(targetTabId: number) {
     workspaceId: session.workspaceId ?? 'global',
     siteId: session.siteId,
   };
+}
+
+function createDisconnectedStatusResponse(
+  presetSettings: SessionPresetSettings,
+  disconnectReason?: SessionDisconnectReason,
+  error?: string
+) {
+  return {
+    connected: false,
+    suspended: false,
+    disconnectReason,
+    showLog: false,
+    autoSend: true,
+    autoApproveTools: false,
+    defaultAutoApproveTools: presetSettings.defaultAutoApproveTools,
+    workspaceId: 'global',
+    error,
+  };
+}
+
+function getDisconnectReasonForHealthStatus(status: GatewayHealthStatus): SessionDisconnectReason {
+  return status === "unauthorized" ? "invalid_token" : "gateway_unavailable";
 }
 
 function handleSetLogVisible(

--- a/bridge-browser/src/background/session_health.ts
+++ b/bridge-browser/src/background/session_health.ts
@@ -1,0 +1,146 @@
+import { BRANDING, PROTOCOL } from '@webcode/shared';
+
+import type { SessionDisconnectReason } from '../types';
+import { updateBadge } from './badge';
+import {
+  getCurrentProtocolSession,
+  getStoredSessionTabIds,
+  removeSession,
+  updateSessionGatewayActivity,
+  type CurrentProtocolSession,
+} from './sessions';
+
+export type GatewayHealthStatus = "online" | "offline" | "unauthorized";
+
+const GATEWAY_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+const GATEWAY_IDLE_GRACE_MS = 10 * 1000;
+const GATEWAY_IDLE_RECHECK_MS = 60 * 1000;
+const GATEWAY_HEALTH_TIMEOUT_MS = 2500;
+const SESSION_EXPIRY_ALARM_PREFIX = "webcode-session-expiry:";
+
+export async function checkGatewayHealth(
+  session: Pick<CurrentProtocolSession, "port" | "token">
+): Promise<GatewayHealthStatus> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), GATEWAY_HEALTH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${session.port}/v1/status`, {
+      cache: "no-store",
+      headers: { [PROTOCOL.authHeaderName]: session.token },
+      signal: controller.signal,
+    });
+
+    if (response.ok) {
+      return "online";
+    }
+
+    return response.status === 403 ? "unauthorized" : "offline";
+  } catch {
+    return "offline";
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export async function recordGatewayActivity(tabId: number): Promise<void> {
+  const session = await updateSessionGatewayActivity(tabId);
+  if (session) {
+    scheduleSessionExpiryCheck(tabId, session.lastGatewayActivityAt);
+  }
+}
+
+export function scheduleSessionExpiryCheck(tabId: number, lastGatewayActivityAt?: number): void {
+  const activityAt = getValidTimestamp(lastGatewayActivityAt) ?? Date.now();
+  const expiresAt = activityAt + GATEWAY_IDLE_TIMEOUT_MS + GATEWAY_IDLE_GRACE_MS;
+  const delayMs = Math.max(1000, expiresAt - Date.now());
+
+  void chrome.alarms.create(getSessionExpiryAlarmName(tabId), {
+    delayInMinutes: delayMs / 60000,
+  });
+}
+
+export async function clearSessionExpiryCheck(tabId: number): Promise<void> {
+  await chrome.alarms.clear(getSessionExpiryAlarmName(tabId));
+}
+
+export async function expireGatewaySession(
+  tabId: number,
+  reason: SessionDisconnectReason
+): Promise<void> {
+  await clearSessionExpiryCheck(tabId);
+  await removeSession(tabId, reason);
+}
+
+export async function scheduleStoredSessionExpiryChecks(): Promise<void> {
+  const tabIds = await getStoredSessionTabIds();
+  await Promise.all(tabIds.map(scheduleStoredSessionExpiryCheck));
+}
+
+export async function handleSessionExpiryAlarm(alarm: chrome.alarms.Alarm): Promise<void> {
+  const tabId = getTabIdFromSessionExpiryAlarm(alarm.name);
+  if (!tabId) {
+    return;
+  }
+
+  const session = await getCurrentProtocolSession(tabId);
+  if (!session) {
+    updateBadge(tabId, false);
+    await clearSessionExpiryCheck(tabId);
+    return;
+  }
+
+  const expiresAt = getSessionExpiresAt(session);
+  if (Date.now() < expiresAt) {
+    scheduleSessionExpiryCheck(tabId, session.lastGatewayActivityAt);
+    return;
+  }
+
+  const status = await checkGatewayHealth(session);
+  if (status === "online") {
+    rescheduleSessionExpiryRecheck(tabId);
+    return;
+  }
+
+  console.log(`${BRANDING.logPrefix} Gateway session expired for tab ${tabId}: ${status}`);
+  await expireGatewaySession(tabId, getDisconnectReasonForHealthStatus(status));
+}
+
+async function scheduleStoredSessionExpiryCheck(tabId: number): Promise<void> {
+  const session = await getCurrentProtocolSession(tabId);
+  if (session) {
+    scheduleSessionExpiryCheck(tabId, session.lastGatewayActivityAt);
+  }
+}
+
+function rescheduleSessionExpiryRecheck(tabId: number): void {
+  void chrome.alarms.create(getSessionExpiryAlarmName(tabId), {
+    delayInMinutes: GATEWAY_IDLE_RECHECK_MS / 60000,
+  });
+}
+
+function getSessionExpiresAt(session: CurrentProtocolSession): number {
+  const activityAt = getValidTimestamp(session.lastGatewayActivityAt) ?? Date.now();
+  return activityAt + GATEWAY_IDLE_TIMEOUT_MS + GATEWAY_IDLE_GRACE_MS;
+}
+
+function getSessionExpiryAlarmName(tabId: number): string {
+  return `${SESSION_EXPIRY_ALARM_PREFIX}${tabId}`;
+}
+
+function getTabIdFromSessionExpiryAlarm(alarmName: string): number | null {
+  if (!alarmName.startsWith(SESSION_EXPIRY_ALARM_PREFIX)) {
+    return null;
+  }
+
+  const tabId = Number(alarmName.slice(SESSION_EXPIRY_ALARM_PREFIX.length));
+  return Number.isInteger(tabId) && tabId > 0 ? tabId : null;
+}
+
+function getDisconnectReasonForHealthStatus(status: GatewayHealthStatus): SessionDisconnectReason {
+  return status === "unauthorized" ? "invalid_token" : "gateway_unavailable";
+}
+
+function getValidTimestamp(value: number | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null;
+}

--- a/bridge-browser/src/background/sessions.ts
+++ b/bridge-browser/src/background/sessions.ts
@@ -1,4 +1,5 @@
-import { normalizeSession, type Session } from '../types';
+import { normalizeSession, type Session, type SessionDisconnectReason } from '../types';
+import { updateBadge } from './badge';
 import { checkUrlSafety, isBridgePageUrl } from './url_safety';
 
 export type CurrentProtocolSession = Session & {
@@ -19,6 +20,21 @@ export async function getSession(tabId: number): Promise<Session | undefined> {
   return normalizeSession(result[key]) ?? undefined;
 }
 
+export async function getStoredSessionTabIds(): Promise<number[]> {
+  const result = await chrome.storage.local.get(null) as Record<string, unknown>;
+  return Object.keys(result)
+    .map(getSessionTabIdFromKey)
+    .filter((tabId): tabId is number => typeof tabId === "number");
+}
+
+export async function getSessionDisconnectReason(
+  tabId: number
+): Promise<SessionDisconnectReason | undefined> {
+  const key = getDisconnectReasonKey(tabId);
+  const result = await chrome.storage.local.get([key]) as Record<string, unknown>;
+  return normalizeDisconnectReason(result[key]);
+}
+
 export async function getCurrentProtocolSession(tabId: number): Promise<CurrentProtocolSession | undefined> {
   const session = await getSession(tabId);
   if (!session) {
@@ -29,7 +45,7 @@ export async function getCurrentProtocolSession(tabId: number): Promise<CurrentP
     return session;
   }
 
-  await removeSession(tabId);
+  await removeSession(tabId, "invalid_session");
   return undefined;
 }
 
@@ -51,7 +67,7 @@ export async function getActiveProtocolSessionResult(
   }
 
   if (!isCurrentProtocolSession(session)) {
-    await removeSession(tabId);
+    await removeSession(tabId, "invalid_session");
     return { status: "invalid" };
   }
 
@@ -74,6 +90,21 @@ export function isCurrentProtocolSession(session: Session): session is CurrentPr
 export async function saveSession(tabId: number, data: Session) {
   const key = `session_${tabId}`;
   await chrome.storage.local.set({ [key]: data });
+  await chrome.storage.local.remove(getDisconnectReasonKey(tabId));
+}
+
+export async function updateSessionGatewayActivity(
+  tabId: number,
+  timestamp = Date.now()
+): Promise<Session | undefined> {
+  const session = await getSession(tabId);
+  if (!session) {
+    return undefined;
+  }
+
+  session.lastGatewayActivityAt = timestamp;
+  await saveSession(tabId, session);
+  return session;
 }
 
 export async function updateSessionLog(tabId: number, showLog: boolean) {
@@ -104,9 +135,15 @@ export function suspendSession(tabId: number) {
   void chrome.tabs.sendMessage(tabId, { type: "STATUS_UPDATE", connected: false }).catch(ignoreRuntimeError);
 }
 
-export async function removeSession(tabId: number) {
+export async function removeSession(tabId: number, reason?: SessionDisconnectReason) {
   const key = `session_${tabId}`;
+  if (reason) {
+    await chrome.storage.local.set({ [getDisconnectReasonKey(tabId)]: reason });
+  } else {
+    await chrome.storage.local.remove(getDisconnectReasonKey(tabId));
+  }
   await chrome.storage.local.remove(key);
+  updateBadge(tabId, false);
   // [Sync] Notify Content Script
   suspendSession(tabId);
 }
@@ -125,4 +162,29 @@ function ignoreRuntimeError(_error: unknown): void {
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+function getSessionTabIdFromKey(key: string): number | null {
+  if (!key.startsWith("session_")) {
+    return null;
+  }
+
+  const tabId = Number(key.slice("session_".length));
+  return Number.isInteger(tabId) && tabId > 0 ? tabId : null;
+}
+
+function getDisconnectReasonKey(tabId: number): string {
+  return `disconnect_${tabId}`;
+}
+
+function normalizeDisconnectReason(value: unknown): SessionDisconnectReason | undefined {
+  if (
+    value === "gateway_unavailable" ||
+    value === "invalid_token" ||
+    value === "invalid_session"
+  ) {
+    return value;
+  }
+
+  return undefined;
 }

--- a/bridge-browser/src/background/tab_lifecycle.ts
+++ b/bridge-browser/src/background/tab_lifecycle.ts
@@ -1,6 +1,7 @@
 import { BRANDING } from '@webcode/shared';
 
 import { updateBadge } from './badge';
+import { clearSessionExpiryCheck } from './session_health';
 import { getCurrentProtocolSession, removeSession, suspendSession } from './sessions';
 import { checkUrlSafety, isBridgePageUrl } from './url_safety';
 
@@ -57,7 +58,10 @@ export async function handleTabUpdated(
 }
 
 export function handleTabRemoved(tabId: number) {
-  void removeSession(tabId);
+  void Promise.all([
+    removeSession(tabId),
+    clearSessionExpiryCheck(tabId),
+  ]);
 }
 
 function ignoreRuntimeError(_error: unknown): void {

--- a/bridge-browser/src/popup/i18n.ts
+++ b/bridge-browser/src/popup/i18n.ts
@@ -1,0 +1,78 @@
+import { BRANDING } from '@webcode/shared';
+
+export type PopupTranslator = (key: string) => string;
+
+const UI: Record<string, Record<string, string>> = {
+  en: {
+    title: BRANDING.bridgeName,
+    connected_text: "✅ Connected to VS Code",
+    port_label: "Port",
+    manual_init: "Manual Initialization",
+    manual_init_title: "Add initialization context to the current input",
+    manual_init_running: "Initializing...",
+    manual_init_done: "Initialization added",
+    manual_init_attached: "Initialization attached",
+    manual_init_failed: "Initialization failed",
+    manual_init_unavailable: "Cannot initialize here",
+    auto_send: "Auto Send Message",
+    auto_approve_tools: "Auto-Approve All Tools",
+    show_log: "Show Floating Log",
+    session_preset: "New Session Preset",
+    session_preset_title: "Show settings used when a new browser session is created",
+    session_preset_hint: "Applies only to new sessions. The current session setting stays unchanged.",
+    checking_connection: "Checking VS Code connection...",
+    default_auto_approve_tools: "Auto-Approve All Tools",
+    disconnected: "🔴 Disconnected from VS Code",
+    suspended: "⏸️ Connection paused on this page",
+    suspended_hint: "Return to the connected site to resume automatically. Local tools stay disabled here.",
+    connection_expired: "🔴 VS Code connection expired",
+    expired_action_title: "Reconnect from VS Code",
+    expired_action_desc: `The VS Code gateway may have stopped after inactivity, or this browser session is no longer valid. In VS Code, click ${BRANDING.productName} in the status bar, start the service, then launch the site again.`,
+    installed_title: "VS Code extension installed?",
+    installed_desc: `Click ${BRANDING.productName} in the VS Code status bar (bottom right) and follow the steps to launch.`,
+    not_installed_title: "VS Code extension not installed?",
+    marketplace_hint: "Search in VS Code Marketplace:",
+  },
+  zh: {
+    title: BRANDING.bridgeName,
+    connected_text: "✅ 已连接到 VS Code",
+    port_label: "端口",
+    manual_init: "手动初始化",
+    manual_init_title: "将初始化上下文追加到当前输入框",
+    manual_init_running: "初始化中...",
+    manual_init_done: "初始化上下文已添加",
+    manual_init_attached: "初始化上下文已作为 txt 附件添加",
+    manual_init_failed: "初始化失败",
+    manual_init_unavailable: "当前页面无法初始化",
+    auto_send: "自动发送消息",
+    auto_approve_tools: "所有工具无需审批",
+    show_log: "显示悬浮日志",
+    session_preset: "新会话预设",
+    session_preset_title: "显示新建浏览器会话时使用的设置",
+    session_preset_hint: "只影响之后新开的会话，不改变当前会话。",
+    checking_connection: "正在检查 VS Code 连接...",
+    default_auto_approve_tools: "所有工具无需审批",
+    disconnected: "🔴 未连接到 VS Code",
+    suspended: "⏸️ 当前页面连接已暂停",
+    suspended_hint: "回到已连接的网站后会自动恢复；本页面无法调用本地工具。",
+    connection_expired: "🔴 VS Code 连接已失效",
+    expired_action_title: "从 VS Code 重新连接",
+    expired_action_desc: `${BRANDING.productName} 网关可能已因长时间无活动自动停止，或当前浏览器会话已失效。请回到 VS Code 右下角点击 ${BRANDING.productName}，启动服务后重新打开当前网站。`,
+    installed_title: "VS Code 插件已安装？",
+    installed_desc: `点击 VS Code 右下角状态栏中的 ${BRANDING.productName}，并按提示启动服务。`,
+    not_installed_title: "VS Code 插件未安装？",
+    marketplace_hint: "在 VS Code 扩展市场中搜索：",
+  },
+};
+
+export function createPopupTranslator(): PopupTranslator {
+  const lang = navigator.language.startsWith("zh") ? "zh" : "en";
+  return (key: string) => UI[lang][key] || UI.en[key];
+}
+
+export function renderInstalledDescription(t: PopupTranslator): string {
+  return t("installed_desc").replace(
+    BRANDING.productName,
+    `<span style="color: #3498db; font-weight: bold">${BRANDING.productName}</span>`
+  );
+}

--- a/bridge-browser/src/popup/index.ts
+++ b/bridge-browser/src/popup/index.ts
@@ -1,12 +1,14 @@
-import { BRANDING } from '@webcode/shared';
 import { isMessageRequest, isStatusResponse, isSuccessResponse } from '../types';
+import { createPopupTranslator, renderInstalledDescription, type PopupTranslator } from './i18n';
 
 type PopupElements = {
+  loadingView: HTMLElement;
   connectedView: HTMLElement;
   disconnectedView: HTMLElement;
   disconnectedStatusCard: HTMLElement;
   installCard: HTMLElement;
   suspendedHint: HTMLElement;
+  expiredCard: HTMLElement;
   statusDot: HTMLElement;
   portDisplay: HTMLElement;
   manualInitBtn: HTMLButtonElement;
@@ -25,7 +27,10 @@ type PopupElements = {
   sessionPresetToggleLabel: HTMLElement;
   defaultAutoApproveToolsLabel: HTMLElement;
   sessionPresetHint: HTMLElement;
+  checkingTitle: HTMLElement;
   disconnectedTitle: HTMLElement;
+  expiredActionTitle: HTMLElement;
+  expiredActionDesc: HTMLElement;
   installedTitle: HTMLElement;
   installedDesc: HTMLElement;
   notInstalledTitle: HTMLElement;
@@ -34,67 +39,12 @@ type PopupElements = {
 
 type PopupContext = {
   elements: PopupElements;
-  t: (key: string) => string;
+  t: PopupTranslator;
 };
 
 type ManualInitStatusState = {
   resetTimer: ReturnType<typeof setTimeout> | null;
   token: number;
-};
-
-const UI: Record<string, Record<string, string>> = {
-  en: {
-    title: BRANDING.bridgeName,
-    connected_text: "✅ Connected to VS Code",
-    port_label: "Port",
-    manual_init: "Manual Initialization",
-    manual_init_title: "Add initialization context to the current input",
-    manual_init_running: "Initializing...",
-    manual_init_done: "Initialization added",
-    manual_init_attached: "Initialization attached",
-    manual_init_failed: "Initialization failed",
-    manual_init_unavailable: "Cannot initialize here",
-    auto_send: "Auto Send Message",
-    auto_approve_tools: "Auto-Approve All Tools",
-    show_log: "Show Floating Log",
-    session_preset: "New Session Preset",
-    session_preset_title: "Show settings used when a new browser session is created",
-    session_preset_hint: "Applies only to new sessions. The current session setting stays unchanged.",
-    default_auto_approve_tools: "Auto-Approve All Tools",
-    disconnected: "🔴 Disconnected from VS Code",
-    suspended: "⏸️ Connection paused on this page",
-    suspended_hint: "Return to the connected site to resume automatically. Local tools stay disabled here.",
-    installed_title: "VS Code extension installed?",
-    installed_desc: `Click ${BRANDING.productName} in the VS Code status bar (bottom right) and follow the steps to launch.`,
-    not_installed_title: "VS Code extension not installed?",
-    marketplace_hint: "Search in VS Code Marketplace:",
-  },
-  zh: {
-    title: BRANDING.bridgeName,
-    connected_text: "✅ 已连接到 VS Code",
-    port_label: "端口",
-    manual_init: "手动初始化",
-    manual_init_title: "将初始化上下文追加到当前输入框",
-    manual_init_running: "初始化中...",
-    manual_init_done: "初始化上下文已添加",
-    manual_init_attached: "初始化上下文已作为 txt 附件添加",
-    manual_init_failed: "初始化失败",
-    manual_init_unavailable: "当前页面无法初始化",
-    auto_send: "自动发送消息",
-    auto_approve_tools: "所有工具无需审批",
-    show_log: "显示悬浮日志",
-    session_preset: "新会话预设",
-    session_preset_title: "显示新建浏览器会话时使用的设置",
-    session_preset_hint: "只影响之后新开的会话，不改变当前会话。",
-    default_auto_approve_tools: "所有工具无需审批",
-    disconnected: "🔴 未连接到 VS Code",
-    suspended: "⏸️ 当前页面连接已暂停",
-    suspended_hint: "回到已连接的网站后会自动恢复；本页面无法调用本地工具。",
-    installed_title: "VS Code 插件已安装？",
-    installed_desc: `点击 VS Code 右下角状态栏中的 ${BRANDING.productName}，并按提示启动服务。`,
-    not_installed_title: "VS Code 插件未安装？",
-    marketplace_hint: "在 VS Code 扩展市场中搜索：",
-  },
 };
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -109,6 +59,7 @@ async function initializePopup(): Promise<void> {
   const currentTab = tabs[0];
   const currentTabId = currentTab?.id;
   if (!currentTabId) {
+    showDisconnectedStatus(context);
     return;
   }
 
@@ -118,22 +69,21 @@ async function initializePopup(): Promise<void> {
 }
 
 function createPopupContext(): PopupContext {
-  const lang = navigator.language.startsWith("zh") ? "zh" : "en";
-  const t = (key: string) => UI[lang][key] || UI.en[key];
-
   return {
     elements: getPopupElements(),
-    t,
+    t: createPopupTranslator(),
   };
 }
 
 function getPopupElements(): PopupElements {
   return {
+    loadingView: document.getElementById("loadingView") as HTMLElement,
     connectedView: document.getElementById("connectedView") as HTMLElement,
     disconnectedView: document.getElementById("disconnectedView") as HTMLElement,
     disconnectedStatusCard: document.getElementById("disconnectedStatusCard") as HTMLElement,
     installCard: document.getElementById("installCard") as HTMLElement,
     suspendedHint: document.getElementById("suspendedHint") as HTMLElement,
+    expiredCard: document.getElementById("expiredCard") as HTMLElement,
     statusDot: document.getElementById("statusDot") as HTMLElement,
     portDisplay: document.getElementById("portDisplay") as HTMLElement,
     manualInitBtn: document.getElementById("manualInitBtn") as HTMLButtonElement,
@@ -152,7 +102,10 @@ function getPopupElements(): PopupElements {
     sessionPresetToggleLabel: document.getElementById("sessionPresetToggleLabel") as HTMLElement,
     defaultAutoApproveToolsLabel: document.getElementById("defaultAutoApproveToolsLabel") as HTMLElement,
     sessionPresetHint: document.getElementById("sessionPresetHint") as HTMLElement,
+    checkingTitle: document.getElementById("checkingTitle") as HTMLElement,
     disconnectedTitle: document.getElementById("disconnectedTitle") as HTMLElement,
+    expiredActionTitle: document.getElementById("expiredActionTitle") as HTMLElement,
+    expiredActionDesc: document.getElementById("expiredActionDesc") as HTMLElement,
     installedTitle: document.getElementById("installedTitle") as HTMLElement,
     installedDesc: document.getElementById("installedDesc") as HTMLElement,
     notInstalledTitle: document.getElementById("notInstalledTitle") as HTMLElement,
@@ -174,19 +127,15 @@ function initializeLabels(context: PopupContext): void {
   elements.sessionPresetToggle.title = t("session_preset_title");
   elements.sessionPresetHint.textContent = t("session_preset_hint");
   elements.defaultAutoApproveToolsLabel.textContent = t("default_auto_approve_tools");
+  elements.checkingTitle.textContent = t("checking_connection");
   elements.disconnectedTitle.textContent = t("disconnected");
   elements.suspendedHint.textContent = t("suspended_hint");
+  elements.expiredActionTitle.textContent = t("expired_action_title");
+  elements.expiredActionDesc.textContent = t("expired_action_desc");
   elements.installedTitle.textContent = t("installed_title");
   elements.installedDesc.innerHTML = renderInstalledDescription(t);
   elements.notInstalledTitle.textContent = t("not_installed_title");
   elements.marketplaceHint.textContent = t("marketplace_hint");
-}
-
-function renderInstalledDescription(t: PopupContext["t"]): string {
-  return t("installed_desc").replace(
-    BRANDING.productName,
-    `<span style="color: #3498db; font-weight: bold">${BRANDING.productName}</span>`
-  );
 }
 
 function listenForSessionSettingChanges(currentTabId: number, elements: PopupElements): void {
@@ -216,6 +165,8 @@ function requestCurrentStatus(currentTabId: number, context: PopupContext): void
     (response: unknown) => {
       if (isStatusResponse(response) && response.connected) {
         showConnectedStatus(response, context.elements);
+      } else if (isStatusResponse(response) && isExpiredDisconnectReason(response.disconnectReason)) {
+        showExpiredStatus(context);
       } else if (isStatusResponse(response) && response.suspended === true) {
         showSuspendedStatus(context);
       } else {
@@ -235,10 +186,11 @@ function showConnectedStatus(
   },
   elements: PopupElements
 ): void {
+  elements.loadingView.classList.add("hidden");
   elements.connectedView.classList.remove("hidden");
   elements.disconnectedView.classList.add("hidden");
   elements.statusDot.classList.add("online");
-  elements.statusDot.classList.remove("suspended");
+  elements.statusDot.classList.remove("suspended", "expired");
   elements.portDisplay.innerText = String(response.port ?? "");
   elements.autoSendInput.checked = response.autoSend !== false;
   elements.autoApproveToolsInput.checked = response.autoApproveTools === true;
@@ -248,31 +200,58 @@ function showConnectedStatus(
 
 function showSuspendedStatus(context: PopupContext): void {
   const { elements, t } = context;
+  elements.loadingView.classList.add("hidden");
   elements.connectedView.classList.add("hidden");
   elements.disconnectedView.classList.remove("hidden");
-  elements.statusDot.classList.remove("online");
+  elements.statusDot.classList.remove("online", "expired");
   elements.statusDot.classList.add("suspended");
-  elements.disconnectedStatusCard.classList.remove("disconnected");
+  elements.disconnectedStatusCard.classList.remove("disconnected", "expired");
   elements.disconnectedStatusCard.classList.add("suspended");
-  elements.disconnectedTitle.classList.remove("disconnected");
+  elements.disconnectedTitle.classList.remove("disconnected", "expired");
   elements.disconnectedTitle.classList.add("suspended");
   elements.disconnectedTitle.textContent = t("suspended");
   elements.suspendedHint.classList.remove("hidden");
+  elements.expiredCard.classList.add("hidden");
+  elements.installCard.classList.add("hidden");
+}
+
+function showExpiredStatus(context: PopupContext): void {
+  const { elements, t } = context;
+  elements.loadingView.classList.add("hidden");
+  elements.connectedView.classList.add("hidden");
+  elements.disconnectedView.classList.remove("hidden");
+  elements.statusDot.classList.remove("online", "suspended");
+  elements.statusDot.classList.add("expired");
+  elements.disconnectedStatusCard.classList.remove("disconnected", "suspended");
+  elements.disconnectedStatusCard.classList.add("expired");
+  elements.disconnectedTitle.classList.remove("disconnected", "suspended");
+  elements.disconnectedTitle.classList.add("expired");
+  elements.disconnectedTitle.textContent = t("connection_expired");
+  elements.suspendedHint.classList.add("hidden");
+  elements.expiredCard.classList.remove("hidden");
   elements.installCard.classList.add("hidden");
 }
 
 function showDisconnectedStatus(context: PopupContext): void {
   const { elements, t } = context;
+  elements.loadingView.classList.add("hidden");
   elements.connectedView.classList.add("hidden");
-  elements.statusDot.classList.remove("online", "suspended");
-  elements.disconnectedStatusCard.classList.remove("suspended");
+  elements.statusDot.classList.remove("online", "suspended", "expired");
+  elements.disconnectedStatusCard.classList.remove("suspended", "expired");
   elements.disconnectedStatusCard.classList.add("disconnected");
-  elements.disconnectedTitle.classList.remove("suspended");
+  elements.disconnectedTitle.classList.remove("suspended", "expired");
   elements.disconnectedTitle.classList.add("disconnected");
   elements.disconnectedTitle.textContent = t("disconnected");
   elements.suspendedHint.classList.add("hidden");
+  elements.expiredCard.classList.add("hidden");
   elements.installCard.classList.remove("hidden");
   elements.disconnectedView.classList.remove("hidden");
+}
+
+function isExpiredDisconnectReason(reason: unknown): boolean {
+  return reason === "gateway_unavailable" ||
+    reason === "invalid_token" ||
+    reason === "invalid_session";
 }
 
 function bindPopupControls(currentTabId: number, context: PopupContext): void {

--- a/bridge-browser/src/types.ts
+++ b/bridge-browser/src/types.ts
@@ -39,6 +39,7 @@ export interface HandshakeResponse {
 export interface StatusResponse {
   connected: boolean;
   suspended?: boolean;
+  disconnectReason?: SessionDisconnectReason;
   error?: string;
   port?: number;
   showLog?: boolean;
@@ -67,11 +68,17 @@ export interface StoredSession {
   autoSend?: boolean;
   autoApproveTools?: boolean;
   workspaceId?: string;
+  lastGatewayActivityAt?: number;
   siteId?: string;
   targetOrigin?: string;
   targetUrl?: string;
   allowedOrigins?: string[];
 }
+
+export type SessionDisconnectReason =
+  | "gateway_unavailable"
+  | "invalid_token"
+  | "invalid_session";
 
 export interface InitGatewayData {
   syncedAiSites?: SyncedAiSite[];
@@ -111,6 +118,7 @@ export function isStoredSession(value: unknown): value is StoredSession {
     isOptionalBoolean(value.autoSend) &&
     isOptionalBoolean(value.autoApproveTools) &&
     isOptionalString(value.workspaceId) &&
+    isOptionalNumber(value.lastGatewayActivityAt) &&
     isOptionalString(value.siteId) &&
     isOptionalString(value.targetOrigin) &&
     isOptionalString(value.targetUrl) &&
@@ -127,6 +135,7 @@ export function normalizeSession(value: unknown): Session | null {
     autoSend: value.autoSend ?? true,
     autoApproveTools: value.autoApproveTools ?? false,
     workspaceId: value.workspaceId ?? "global",
+    lastGatewayActivityAt: value.lastGatewayActivityAt,
     siteId: value.siteId,
     targetOrigin: value.targetOrigin ?? value.allowedOrigins?.[0],
     targetUrl: value.targetUrl,
@@ -170,6 +179,10 @@ function isOptionalBoolean(value: unknown): boolean {
 
 function isOptionalString(value: unknown): boolean {
   return value === undefined || typeof value === "string";
+}
+
+function isOptionalNumber(value: unknown): boolean {
+  return value === undefined || typeof value === "number";
 }
 
 function isOptionalStringArray(value: unknown): boolean {

--- a/gateway-vscode/src/gateway.ts
+++ b/gateway-vscode/src/gateway.ts
@@ -141,7 +141,11 @@ export class GatewayManager {
         if (!this.app) {return;}
 
         this.app.use(createCorsMiddleware(config, this.log.bind(this)));
-        this.app.use(createRequestLoggerMiddleware(() => this.resetWatchdog(), this.log.bind(this)));
+        this.app.use(createRequestLoggerMiddleware(
+            () => this.resetWatchdog(),
+            this.log.bind(this),
+            { skipWatchdogPaths: ['/v1/status'] }
+        ));
         this.app.use(createAuthMiddleware(() => this.authToken, this.log.bind(this)));
 
         registerConfigRoutes(this.app, config, this.log.bind(this));

--- a/gateway-vscode/src/gateway/initRoutes.ts
+++ b/gateway-vscode/src/gateway/initRoutes.ts
@@ -9,6 +9,10 @@ export function registerConfigRoutes(
     config: GatewayConfig,
     log: GatewayLogger
 ): void {
+    app.get('/v1/status', (_req, res) => {
+        res.json({ ok: true });
+    });
+
     app.get('/v1/init', (req, res) => {
         log('📥 Init Sync: Browser requested default rules and prompts');
 

--- a/gateway-vscode/src/gateway/middleware.ts
+++ b/gateway-vscode/src/gateway/middleware.ts
@@ -27,10 +27,15 @@ export function createCorsMiddleware(config: GatewayConfig, log: GatewayLogger):
 
 export function createRequestLoggerMiddleware(
     resetWatchdog: () => void,
-    log: GatewayLogger
+    log: GatewayLogger,
+    options: { skipWatchdogPaths?: readonly string[] } = {}
 ): express.RequestHandler {
+    const skipWatchdogPaths = new Set(options.skipWatchdogPaths ?? []);
+
     return (req, res, next) => {
-        resetWatchdog();
+        if (!skipWatchdogPaths.has(req.path)) {
+            resetWatchdog();
+        }
         const start = Date.now();
         if (req.method !== 'OPTIONS') {
             log(`🔔 [${req.method}] ${req.url}`);

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -105,6 +105,7 @@ export interface Session {
   autoSend: boolean;
   autoApproveTools: boolean;
   workspaceId: string;
+  lastGatewayActivityAt?: number;
   siteId?: string;
   targetOrigin?: string;
   targetUrl?: string;


### PR DESCRIPTION
- Add a gateway health check that does not extend the idle watchdog.

- Clear browser sessions and badges when gateway health checks fail.

- Show checking and expired connection states in the popup.